### PR TITLE
fix: more informative msg in request in case of failed deploy

### DIFF
--- a/web/module/requests.py
+++ b/web/module/requests.py
@@ -12,6 +12,7 @@ import threading
 import asyncio
 import logging
 from web.module.capabilities import Capabilities as cap
+from web.settings import Settings as settings
 
 logger = logging.getLogger(__name__)
 
@@ -62,9 +63,11 @@ async def req_get_info(request, req_id):
             result = extra_result + result
 
         if req.state.is_error():
+            unit_name = settings.app.get('unit_name', 'N/A')
+            deploy_error_msg = 'deploy of machine \'{}\' on unit \'{}\' failed'.format(req.machine, unit_name)
             result[0]['is_last'] = False
             result.append({
-                'exception': 'request failed',
+                'exception': deploy_error_msg if req.type is data.RequestType.DEPLOY else 'request failed',
                 'exception_args': [],
                 'exception_traceback': [],
                 'is_last': True


### PR DESCRIPTION
request will yield more informative error msg for failed deploys, like `deploy of machine '245' on unit 'test_danek' failed`